### PR TITLE
Add initial support for parsing SAM files for effects

### DIFF
--- a/SAJSON.cpp
+++ b/SAJSON.cpp
@@ -125,6 +125,7 @@ namespace SuperAnim{
 
 		// std::string theSuperAnimFile include the absolute path
 		SuperAnimMainDef *Load_GetSuperAnimMainDef(const std::string &theSuperAnimFile);
+        SuperAnimMainDef *Load_GetSuperAnimMainDefEffect(const std::string &theSuperAnimFile);
 		void UnloadSuperAnimMainDef(const std::string &theName);
 	};
 
@@ -168,14 +169,20 @@ unsigned char* GetFileData(const char* pszFileName, const char* pszMode, unsigne
 
 
 int main(int argc, char* argv[]){
-    if(argc != 2){
+    if(argc < 2){
         printf("usage: SAJSON sam_path\n");
         return 1;
     }
     
     
-    
-    SuperAnim::SuperAnimMainDef* p = SuperAnim::SuperAnimDefMgr::GetInstance()->Load_GetSuperAnimMainDef(argv[1]);
+    SuperAnim::SuperAnimMainDef* p;
+    if (argc == 2) {
+        p = SuperAnim::SuperAnimDefMgr::GetInstance()->Load_GetSuperAnimMainDef(argv[1]);
+    } else {
+        // ex: SAJON sam_path -effect
+        // will run as long as there are more than 2 arguments
+        p = SuperAnim::SuperAnimDefMgr::GetInstance()->Load_GetSuperAnimMainDefEffect(argv[1]);
+    }
     
     printf("{");
     

--- a/SuperAnimCore.cpp
+++ b/SuperAnimCore.cpp
@@ -214,12 +214,14 @@ namespace SuperAnim {
 		
 		// std::string theSuperAnimFile include the absolute path
 		bool LoadSuperAnimMainDef(const std::string &theSuperAnimFile);
+		bool LoadSuperAnimMainDefEffect(const std::string &theSuperAnimFile);
 	public:
 		static SuperAnimDefMgr *GetInstance();
 		static void DestroyInstance();
 
 		// std::string theSuperAnimFile include the absolute path
 		SuperAnimMainDef *Load_GetSuperAnimMainDef(const std::string &theSuperAnimFile);
+		SuperAnimMainDef *Load_GetSuperAnimMainDefEffect(const std::string &theSuperAnimFile);
 		void UnloadSuperAnimMainDef(const std::string &theName);
 	};
 	
@@ -560,6 +562,216 @@ namespace SuperAnim {
 		//		return true;
 		return a.mStartFrameNum < b.mStartFrameNum;
 	}
+	bool SuperAnimDefMgr::LoadSuperAnimMainDefEffect(const std::string &theSuperAnimFile)
+	{
+		std::string aFullPath = theSuperAnimFile;
+		
+		std::string aCurDir = "";
+		int aLastSlash = max((int) theSuperAnimFile.rfind('\\'), (int) theSuperAnimFile.rfind('/'));
+		if (aLastSlash != std::string::npos){
+			aCurDir = theSuperAnimFile.substr(0, aLastSlash);
+		}
+
+		unsigned long aFileSize = 0;
+		unsigned char *aFileBuffer = GetFileData(aFullPath.c_str(), "rb", &aFileSize);
+		if (aFileBuffer == NULL)
+		{
+			assert(false && "Cannot allocate memory.");
+			return false;
+		}
+		BufferReader aBuffer;
+		aBuffer.SetData(aFileBuffer, aFileSize);
+		// free memory
+		delete[] aFileBuffer;
+		
+		if (aBuffer.ReadLong() != 0x2E53414D)
+		{
+			assert(false && "Bad file format.");
+			return false;
+		}
+		
+		int aVersion = aBuffer.ReadLong();
+		
+		if (aVersion != SAM_VERSION)
+		{
+			assert(false && "Wrong version.");
+			return false;
+		}
+		
+		SuperAnimMainDef &aMainDef = mMainDefCache[theSuperAnimFile]; 
+		aMainDef.mAnimRate = aBuffer.ReadByte();
+		// TODO: refactor how these values are read to reduce duplicate code
+		// Key differences for effects start here - they seem to have a smaller data size than unit animations
+		aMainDef.mX = aBuffer.ReadShort() / TWIPS_PER_PIXEL;
+		aMainDef.mY = aBuffer.ReadShort() / TWIPS_PER_PIXEL;
+		aMainDef.mWidth = aBuffer.ReadShort() / TWIPS_PER_PIXEL;
+		aMainDef.mHeight = aBuffer.ReadShort() / TWIPS_PER_PIXEL;
+		// Key differences for effects end here - they seem to have a smaller data size than unit animations
+		
+		SuperAnimLabelArray aSuperAnimLabelArray;
+		
+		int aNumImages = aBuffer.ReadShort();
+		aMainDef.mImageVector.resize(aNumImages);
+		for (int anImageNum = 0; anImageNum < aNumImages; ++anImageNum)
+		{
+			SuperAnimImage &aSuperAnimImage = aMainDef.mImageVector[anImageNum];
+			aSuperAnimImage.mImageName = aBuffer.ReadString();
+			aSuperAnimImage.mWidth = aBuffer.ReadShort();
+			aSuperAnimImage.mHeight = aBuffer.ReadShort();
+			
+			aSuperAnimImage.mTransform.mMatrix.m00 = aBuffer.ReadLong() / (LONG_TO_FLOAT * TWIPS_PER_PIXEL);
+			aSuperAnimImage.mTransform.mMatrix.m01 = -aBuffer.ReadLong() / (LONG_TO_FLOAT * TWIPS_PER_PIXEL);
+			aSuperAnimImage.mTransform.mMatrix.m10 = -aBuffer.ReadLong() / (LONG_TO_FLOAT * TWIPS_PER_PIXEL);
+			aSuperAnimImage.mTransform.mMatrix.m11 = aBuffer.ReadLong() / (LONG_TO_FLOAT * TWIPS_PER_PIXEL);
+			aSuperAnimImage.mTransform.mMatrix.m02 = aBuffer.ReadShort() / TWIPS_PER_PIXEL;
+			aSuperAnimImage.mTransform.mMatrix.m12 = aBuffer.ReadShort() / TWIPS_PER_PIXEL;
+			
+			std::string aImagePath;
+			if (aCurDir.empty()) {
+				aImagePath = aSuperAnimImage.mImageName;
+			} else {
+				aImagePath = aCurDir + '/' + aSuperAnimImage.mImageName;
+			}
+			
+			aSuperAnimImage.mSpriteId = LoadSuperAnimSprite(aImagePath);
+		}
+		
+		int aNumFrames = aBuffer.ReadShort();
+		assert(aNumFrames > 0 && "We don't have valid frames.");
+		aMainDef.mStartFrameNum = 0;
+		aMainDef.mEndFrameNum = aNumFrames - 1;
+		aMainDef.mFrames.resize(aNumFrames);
+		IntToSuperAnimObjectMap aCurObjectMap;
+		for (int aFrameNum = 0; aFrameNum < aNumFrames; ++aFrameNum)
+		{
+			SuperAnimFrame &aFrame = aMainDef.mFrames[aFrameNum];
+			uchar aFrameFlags = aBuffer.ReadByte();
+			
+			if (aFrameFlags & FRAMEFLAGS_REMOVES)
+			{
+				int aNumRemoves = aBuffer.ReadByte();
+				for (int aRemoveNum = 0; aRemoveNum < aNumRemoves; ++ aRemoveNum)
+				{
+					int anObjectId = aBuffer.ReadShort();
+					IntToSuperAnimObjectMap::iterator anIt = aCurObjectMap.find(anObjectId);
+					if (anIt != aCurObjectMap.end())
+					{
+						aCurObjectMap.erase(anIt);
+					}
+				}
+			}
+			
+			if (aFrameFlags & FRAMEFLAGS_ADDS)
+			{
+				int aNumAdds = aBuffer.ReadByte();
+				for(int anAddNum = 0; anAddNum < aNumAdds; ++anAddNum)
+				{
+					int anObjNum = (aBuffer.ReadShort() & 0x07FF);
+					SuperAnimObject& aSuperAnimObject = aCurObjectMap[anObjNum];
+					aSuperAnimObject.mObjectNum = anObjNum;
+					aSuperAnimObject.mResNum = aBuffer.ReadByte();
+					aSuperAnimObject.mColor = Color(255, 255, 255, 255);
+				}
+			}
+			
+			if (aFrameFlags & FRAMEFLAGS_MOVES)
+			{
+				int aNumMoves = aBuffer.ReadByte();
+				for (int aMoveNum = 0; aMoveNum < aNumMoves; ++ aMoveNum)
+				{
+					unsigned short aFlagsAndObjectNum = aBuffer.ReadShort();
+					int anObjectNum = aFlagsAndObjectNum & 0x03FF;
+					
+					IntToSuperAnimObjectMap::iterator anIt = aCurObjectMap.find(anObjectNum);
+					if (anIt == aCurObjectMap.end())
+						continue;
+					SuperAnimObject &aSuperAnimObject = anIt->second;
+					aSuperAnimObject.mTransform.mMatrix.LoadIdentity();
+					
+					if (aFlagsAndObjectNum & MOVEFLAGS_MATRIX)
+					{
+						aSuperAnimObject.mTransform.mMatrix.m00 = aBuffer.ReadLong() / LONG_TO_FLOAT;
+						aSuperAnimObject.mTransform.mMatrix.m01 = -aBuffer.ReadLong() / LONG_TO_FLOAT;
+						aSuperAnimObject.mTransform.mMatrix.m10 = -aBuffer.ReadLong() / LONG_TO_FLOAT;
+						aSuperAnimObject.mTransform.mMatrix.m11 = aBuffer.ReadLong() / LONG_TO_FLOAT;
+					}
+					else if (aFlagsAndObjectNum & MOVEFLAGS_ROTATE)
+					{
+						float aRot = aBuffer.ReadShort() / 1000.0f;
+						float sinRot = sinf(aRot);
+						float cosRot = cosf(aRot);
+						aSuperAnimObject.mTransform.mMatrix.m00 = cosRot;
+						aSuperAnimObject.mTransform.mMatrix.m01 = sinRot;
+						aSuperAnimObject.mTransform.mMatrix.m10 = -sinRot;
+						aSuperAnimObject.mTransform.mMatrix.m11 = cosRot;
+					}
+					
+					SuperAnimMatrix3 aMatrix;
+					aMatrix.LoadIdentity();
+					if (aFlagsAndObjectNum & MOVEFLAGS_LONGCOORDS)
+					{
+						aMatrix.m02 = aBuffer.ReadLong() / TWIPS_PER_PIXEL;
+						aMatrix.m12 = aBuffer.ReadLong() / TWIPS_PER_PIXEL;
+					}
+					else
+					{
+						aMatrix.m02 = aBuffer.ReadShort() / TWIPS_PER_PIXEL;
+						aMatrix.m12 = aBuffer.ReadShort() / TWIPS_PER_PIXEL;
+					}
+					aSuperAnimObject.mTransform.mMatrix = aMatrix * aSuperAnimObject.mTransform.mMatrix;
+					
+					if (aFlagsAndObjectNum & MOVEFLAGS_COLOR)
+					{
+						aSuperAnimObject.mColor.mRed = aBuffer.ReadByte();
+						aSuperAnimObject.mColor.mGreen = aBuffer.ReadByte();
+						aSuperAnimObject.mColor.mBlue = aBuffer.ReadByte();
+						aSuperAnimObject.mColor.mAlpha = aBuffer.ReadByte();
+					}
+				}
+			}
+			
+			if (aFrameFlags & FRAMEFLAGS_FRAME_NAME)
+			{
+				std::string aFrameName = aBuffer.ReadString();
+				SuperAnimLabel aLabel;
+				aLabel.mLabelName = aFrameName;
+				aLabel.mStartFrameNum = aFrameNum;
+				//aMainDef.mLabels.insert(StringToIntMap::value_type(aFrameName, aFrameNum));
+				aSuperAnimLabelArray.push_back(aLabel);
+			}
+			
+			aFrame.mObjectVector.resize(aCurObjectMap.size());
+			aFrame.mObjectVector.clear();
+			for (IntToSuperAnimObjectMap::iterator anIt = aCurObjectMap.begin(); anIt != aCurObjectMap.end(); ++anIt)
+			{
+				SuperAnimObject &anObject = anIt->second;
+				aFrame.mObjectVector.push_back(anObject);
+			}
+
+		}
+		
+		// sort the label array & calculate the end frame for each label
+		std::sort(aSuperAnimLabelArray.begin(), aSuperAnimLabelArray.end(), SuperAnimLabelLess);
+		if (aSuperAnimLabelArray.size() > 1) {
+			for (int i = 0; i < aSuperAnimLabelArray.size() - 1; i++) {
+				SuperAnimLabel& aCurLabel = aSuperAnimLabelArray[i];
+				const SuperAnimLabel& aNextLabel = aSuperAnimLabelArray[i + 1];
+				aCurLabel.mEndFrameNum = aNextLabel.mStartFrameNum - 1;
+			}
+			SuperAnimLabel& aLastLabel = aSuperAnimLabelArray[aSuperAnimLabelArray.size() - 1];
+			aLastLabel.mEndFrameNum = aMainDef.mEndFrameNum;
+		} else {
+			// only have one section
+			SuperAnimLabel& aLabel = aSuperAnimLabelArray[0];
+			aLabel.mEndFrameNum = aMainDef.mEndFrameNum;
+		}
+		aMainDef.mLabels.clear();
+		for (int i = 0; i < aSuperAnimLabelArray.size(); i++) {
+			aMainDef.mLabels.push_back(aSuperAnimLabelArray[i]);
+		}
+		
+		return true;
+	}
 	bool SuperAnimDefMgr::LoadSuperAnimMainDef(const std::string &theSuperAnimFile)
 	{
 		std::string aFullPath = theSuperAnimFile;
@@ -780,6 +992,20 @@ namespace SuperAnim {
 			return NULL;
 		
 		return Load_GetSuperAnimMainDef(theSuperAnimFile);
+	}
+
+	SuperAnimMainDef *SuperAnimDefMgr::Load_GetSuperAnimMainDefEffect(const std::string &theSuperAnimFile)
+	{
+		SuperAnimMainDefMap::iterator anItr = mMainDefCache.find(theSuperAnimFile);
+		if (anItr != mMainDefCache.end())
+		{
+			return &anItr->second;
+		}
+		
+		if (LoadSuperAnimMainDefEffect(theSuperAnimFile) == false)
+			return NULL;
+		
+		return Load_GetSuperAnimMainDefEffect(theSuperAnimFile);
 	}
 	
 	void SuperAnimDefMgr::UnloadSuperAnimMainDef(const std::string &theName)


### PR DESCRIPTION
Add support for parsing effect SAM files, which have a slightly different format to the unit SAM files.

Based on some local dev-testing, I found that the X, Y, width, and height values for effects are of type "short" instead of "long" for effect SAM files. Other than that, the SAM files are identical to the unit SAM files.

To run the effect-specific parsing code (since I don't currently have a great way to automatically check), pass in any third flag to the application. For example, `SAJON sam_path -effect` and `SAJON sam_path any_flag` will work to parse the aforementioned properties as "short" values.

Unfortunately, with C++ not being my strong suit and due to lack of time to clean up at the time of writing, I've gone ahead with copy-pasting the original `LoadSuperAnimMainDef` code and modifying that one section of code that is different between unit SAM files and effect SAM files. Ideally this would be refactored to reduce duplication of code and also automatically detect which code path to use.